### PR TITLE
Remove unused attr Notifications::Log#webhook_url

### DIFF
--- a/lib/query_track/notifications/log.rb
+++ b/lib/query_track/notifications/log.rb
@@ -1,7 +1,7 @@
 module QueryTrack
   module Notifications
     class Log
-      attr_reader :code, :duration, :webhook_url
+      attr_reader :code, :duration
 
       def initialize(code, duration)
         @code = code.strip


### PR DESCRIPTION
It's irrelevant to the `Log` class.