### PR TITLE
Add custom app directory for traces

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ end
 
 ### Filters
 
-To avoid noisy warnings from used gems, and places where fat queries are justified, you can filters SQL by backtrace. 
+To avoid noisy warnings from used gems, and places where fat queries are justified, you can filters SQL by backtrace.
 For example, you have installed `activeadmin` and want to skip everything from `app/admin`:
 
 ```ruby
@@ -50,10 +50,22 @@ QueryTrack::Settings.configure do |config|
   config.filters = ['app/admin']
 end
 ```
+### App Directory
+
+QueryTrack finds the trace by filtering the caller by the app directory.
+By default, the app directory is set to 'app', the default for Rails apps.
+For apps that have a non-stanard app directory, this can be set with the `app_dir` config field:
+
+```ruby
+QueryTrack::Settings.configure do |config|
+  config.duration = 0.5
+  config.app_dir = 'backend'
+end
+```
 
 ### Enable/Disable toggle
 
-Enable/disable with ENV variables to turn it on/off without code push. By default *QueryTrack* is enabled. 
+Enable/disable with ENV variables to turn it on/off without code push. By default *QueryTrack* is enabled.
 
 ```ruby
 QueryTrack::Settings.configure do |config|

--- a/lib/query_track/settings.rb
+++ b/lib/query_track/settings.rb
@@ -14,5 +14,7 @@ module QueryTrack
     setting :filters, []
 
     setting :enabled, true
+
+    setting :app_dir, 'app'
   end
 end

--- a/lib/query_track/trace.rb
+++ b/lib/query_track/trace.rb
@@ -7,7 +7,7 @@ module QueryTrack
     end
 
     def call
-      full_trace.select { |v| v =~ %r{app/} }[0]
+      full_trace.select { |v| v =~ %r{#{QueryTrack::Settings.config.app_dir}/} }[0]
     end
   end
 end

--- a/spec/query_track/trace_spec.rb
+++ b/spec/query_track/trace_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe QueryTrack::Trace do
+  let(:app_dir_path) { 'app/admin/user.rb' }
+  let(:fake_trace) { [app_dir_path, 'lib/config/query_track.rb'] }
+
+  before do
+    QueryTrack::Settings.configure do |config|
+      config.duration = 1.0
+    end
+  end
+
+  context 'has default app directory' do
+    it 'should return path matching app directory' do
+      expect(QueryTrack::Trace.new(fake_trace).call).to eq app_dir_path
+    end
+  end
+
+  context 'has override app directory' do
+    let(:app_dir_path) { 'backend/models/user.rb' }
+
+    before do
+      QueryTrack::Settings.configure do |config|
+        config.app_dir = 'backend'
+      end
+    end
+
+    it 'should return path matching app directory' do
+      expect(QueryTrack::Trace.new(fake_trace).call).to eq app_dir_path
+    end
+  end
+end


### PR DESCRIPTION
We would like to use this gem in our Sinatra app, which does not conform to Rails conventions. This adds a config setting for `app_dir` which defaults to `'app`' that would allow us to override it with our app directory.